### PR TITLE
web-server: clean up websocket and queue state when logout / closing browser

### DIFF
--- a/matching-service/src/types.ts
+++ b/matching-service/src/types.ts
@@ -1,12 +1,16 @@
 import { WebSocket } from "ws";
 
+export interface ExtendedWebSocket extends WebSocket {
+  userId?: string;
+}
+
 export interface User {
   id: string;
   difficulty: string;
   language: string;
   topics: string[];
   joinTime: number;
-  ws?: WebSocket;
+  ws?: ExtendedWebSocket;
 }
 
 export interface Match {

--- a/web-server/src/components/Layout.tsx
+++ b/web-server/src/components/Layout.tsx
@@ -22,10 +22,25 @@ export default function Layout() {
   ];
 
   const handleLogout = async () => {
-    await fetch("http://localhost:3002/auth/logout", {
-      method: "POST",
-      credentials: "include", // to send cookies
-    });
+    // Clean up WebSocket connection if it exists
+    const ws = window.matchmakingWS;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      // Just close the connection - backend handles queue cleanup
+      ws.close();
+      delete window.matchmakingWS;
+    }
+
+    // Call backend logout
+    try {
+      await fetch("http://localhost:3002/auth/logout", {
+        method: "POST",
+        credentials: "include",
+      });
+    } catch (error) {
+      console.error("Logout request failed:", error);
+    }
+
+    // Always navigate to landing page
     navigate("/");
   };
 

--- a/web-server/src/pages/Home.tsx
+++ b/web-server/src/pages/Home.tsx
@@ -9,7 +9,7 @@ import {
   Button,
   TextField,
   Alert,
-  Stack
+  Stack,
 } from "@mui/material";
 import { useMatchmaking } from "../hooks/useMatchmaking";
 
@@ -18,12 +18,11 @@ export default function Home() {
   const [difficulty, setDifficulty] = useState("easy");
   const [language, setLanguage] = useState("python");
 
-  const { match, findMatch, isFinding, timeProgress, error, resetMatch } = useMatchmaking(userId, difficulty, language, [
-    "arrays",
-  ], 60);
+  const { match, findMatch, isFinding, timeProgress, error, resetMatch } =
+    useMatchmaking(userId, difficulty, language, ["arrays"], 60);
 
   const handleFindMatch = async () => {
-      await findMatch(); 
+    await findMatch();
   };
 
   return (
@@ -67,20 +66,20 @@ export default function Home() {
       </FormControl>
 
       <Stack direction="row" spacing={2}>
-        <Button 
-          variant="contained" 
+        <Button
+          variant="contained"
           onClick={handleFindMatch}
-          disabled={isFinding || !!match}>
-            
-          {match 
+          disabled={isFinding || !!match}
+        >
+          {match
             ? "Matched!"
             : isFinding
-            ? 'Finding (${timeProgress}s)'
+            ? `Finding (${timeProgress}s)`
             : "Find Match"}
         </Button>
 
-        { (match || error) && (
-          <Button variant='outlined' onClick={resetMatch}>
+        {(match || error) && (
+          <Button variant="outlined" onClick={resetMatch}>
             Find Again
           </Button>
         )}
@@ -94,7 +93,7 @@ export default function Home() {
 
       {isFinding && !match && (
         <Typography variant="body2" color="text.secondary">
-          Searching for peer... progressed {timeProgress}s 
+          Searching for peer... progressed {timeProgress}s
         </Typography>
       )}
 

--- a/web-server/src/types/index.ts
+++ b/web-server/src/types/index.ts
@@ -18,3 +18,9 @@ export interface MatchFoundMessage {
 }
 
 export type WebSocketMessage = MatchFoundMessage; // can add more msg types in future
+
+declare global {
+  interface Window {
+    matchmakingWS?: WebSocket;
+  }
+}


### PR DESCRIPTION
- On logout or page refresh, the client’s WebSocket connection is disconnected
- When the matching service detects the disconnection, it performs cleanup:
  - Checks the active connections in memory, and if the user was in the matchmaking queue, their state is cleared
  - Removes the user from the Redis queue to prevent stale entries